### PR TITLE
Switching debian repository to HTTP

### DIFF
--- a/tasks/os_Debian.yml
+++ b/tasks/os_Debian.yml
@@ -7,7 +7,7 @@
 
 - name: add repository
   apt_repository:
-    repo: 'deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main'
+    repo: 'deb [arch=amd64] http://packages.microsoft.com/repos/vscode stable main'
     filename: vscode
     state: present
     update_cache: yes


### PR DESCRIPTION
Microsoft installs a redundant vscode.list entry in the apt sources.
Matching the new line works better.

Fixes #11