### PR TITLE
Add support for macOS using Homebrew

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -59,9 +59,9 @@ galaxy_info:
   #  - 10
   #  - 6
   #  - 9
-  #- name: MacOSX
-  #  versions:
-  #  - all
+  - name: MacOSX
+    versions:
+    - all
   #  - 10.10
   #  - 10.11
   #  - 10.12

--- a/tasks/os_Darwin.yml
+++ b/tasks/os_Darwin.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Check if Homebrew is installed
+  stat:
+    path: /usr/local/bin/brew
+  register: homebrew_installed
+
+- name: install vscode
+  homebrew_cask:
+    name: visual-studio-code
+    state: present
+  when:
+    - homebrew_installed
+    - vscode_install


### PR DESCRIPTION
Add support for macOS using Homebrew:
- vscode_install supported
- vscode_insiders_install NOT supported 